### PR TITLE
Fix prepare inputs labels for multimodal

### DIFF
--- a/llava/model/llava_arch.py
+++ b/llava/model/llava_arch.py
@@ -258,15 +258,19 @@ class LlavaMetaForCausalLM(ABC):
         new_input_embeds = []
         new_labels = []
         cur_image_idx = 0
+        #add assert total number of image in batch == the number of image in input_ids
+        assert sum([(cur_input_ids == IMAGE_TOKEN_INDEX).sum() for cur_input_ids in input_ids]) == len(image_features)
+        
         for batch_idx, cur_input_ids in enumerate(input_ids):
             num_images = (cur_input_ids == IMAGE_TOKEN_INDEX).sum()
             if num_images == 0:
-                cur_image_features = image_features[cur_image_idx]
+                # as there are no images in this input so we don't need to use image_features here
+                # cur_image_features = image_features[cur_image_idx]
                 cur_input_embeds_1 = self.get_model().embed_tokens(cur_input_ids)
-                cur_input_embeds = torch.cat([cur_input_embeds_1, cur_image_features[0:0]], dim=0)
-                new_input_embeds.append(cur_input_embeds)
+                # cur_input_embeds = torch.cat([cur_input_embeds_1, cur_image_features[0:0]], dim=0)
+                new_input_embeds.append(cur_input_embeds_1)
                 new_labels.append(labels[batch_idx])
-                cur_image_idx += 1
+                # cur_image_idx += 1 --> remove this as we don't have any images in this input
                 continue
 
             image_token_indices = [-1] + torch.where(cur_input_ids == IMAGE_TOKEN_INDEX)[0].tolist() + [cur_input_ids.shape[0]]

--- a/llava/model/llava_arch.py
+++ b/llava/model/llava_arch.py
@@ -264,13 +264,9 @@ class LlavaMetaForCausalLM(ABC):
         for batch_idx, cur_input_ids in enumerate(input_ids):
             num_images = (cur_input_ids == IMAGE_TOKEN_INDEX).sum()
             if num_images == 0:
-                # as there are no images in this input so we don't need to use image_features here
-                # cur_image_features = image_features[cur_image_idx]
                 cur_input_embeds_1 = self.get_model().embed_tokens(cur_input_ids)
-                # cur_input_embeds = torch.cat([cur_input_embeds_1, cur_image_features[0:0]], dim=0)
                 new_input_embeds.append(cur_input_embeds_1)
                 new_labels.append(labels[batch_idx])
-                # cur_image_idx += 1 --> remove this as we don't have any images in this input
                 continue
 
             image_token_indices = [-1] + torch.where(cur_input_ids == IMAGE_TOKEN_INDEX)[0].tolist() + [cur_input_ids.shape[0]]


### PR DESCRIPTION
+ Add assert to make sure number of images == number of image tokens in inputs
+ Fix the case [where num_images == 0](https://github.com/LLaVA-VL/LLaVA-NeXT/blob/inference/llava/model/llava_arch.py#L263):
    + We don't need to use image_features at here
     + cannot set `cur_image_idx += 1 `--> will run into error for many cases. For example, if batch contains 2 data points without containing images in inputs