### PR TITLE
Fix: videos in LLaVa-OV

### DIFF
--- a/docs/LLaVA_OneVision_Tutorials.ipynb
+++ b/docs/LLaVA_OneVision_Tutorials.ipynb
@@ -345,6 +345,7 @@
     "\n",
     "input_ids = tokenizer_image_token(prompt_question, tokenizer, IMAGE_TOKEN_INDEX, return_tensors=\"pt\").unsqueeze(0).to(device)\n",
     "image_sizes = [frame.size for frame in video_frames]\n",
+    "modalities = [\"video\"] * len(video_frames)\n",
     "\n",
     "# Generate response\n",
     "cont = model.generate(\n",
@@ -354,7 +355,7 @@
     "    do_sample=False,\n",
     "    temperature=0,\n",
     "    max_new_tokens=4096,\n",
-    "    modalities=[\"video\"],\n",
+    "    modalities=modalities,\n",
     ")\n",
     "text_outputs = tokenizer.batch_decode(cont, skip_special_tokens=True)\n",
     "print(text_outputs[0])"


### PR DESCRIPTION
Currently running the demo notebook for LLaVA OneVision for video modality doesn't apply pooling for all video patches/frames, because the `modality` list holds values for each prompt, while videos can contain several frames. This PR replicates the `modality` list by copying it for all video frames in the demo notebook

I tried to see if we can expand the modalities inside modeling code, but seems like it's hard to infer which visual in the input is image or video, so I decided to delegate expansion to users. 