### PR TITLE
Modailities param in LLaVA-NeXT documentation

### DIFF
--- a/docs/LLaVA-NeXT.md
+++ b/docs/LLaVA-NeXT.md
@@ -47,6 +47,8 @@ cont = model.generate(
     do_sample=False,
     temperature=0,
     max_new_tokens=256,
+    # Modalities should be the same size as the batch size
+    modalities=["image"]*input_ids.shape[0]
 )
 text_outputs = tokenizer.batch_decode(cont, skip_special_tokens=True)
 print(text_outputs)


### PR DESCRIPTION
The llava model requires the modalities parameter to be broadcasted to the batch size, otherwise the zip statement on line 442 in llava/model/llava_arch.py reduces the batch size to 1 (the default length of this parameter). Not having this in the .generate call leads to batches of size 1 to be generated even when a larger batch size is passed in. 

I think adding this to the documentation would make it a little more clear. Or maybe doing auto broadcasting of the modalities parameter if the input is a batch and this parameter isn't changed by the user.