### PR TITLE
Remove HuggingFace token

### DIFF
--- a/scripts/archived/entry_cmd.sh
+++ b/scripts/archived/entry_cmd.sh
@@ -4,7 +4,7 @@ export http_proxy=http://sys-proxy-rd-relay.byted.org:8118;
 export https_proxy=http://sys-proxy-rd-relay.byted.org:8118;
 
 export HF_HOME=/mnt/bn/vl-research-boli01-cn/.cache/huggingface;
-export HF_TOKEN="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";
+export HF_TOKEN="HF_TOKEN";
 export HF_HUB_ENABLE_HF_TRANSFER="1";
 
 cd /mnt/bn/vl-research-boli01-cn/projects/zzz/lmms-eval;


### PR DESCRIPTION
This PR is to remove the project's HuggingFace token from the repository. You should also ensure that this token is then properly revoked on HuggingFace. 

See https://www.tenable.com/security/research/tra-2025-16