### PR TITLE
docs(docs/LLaVA_Video_1003.md) update: Fix Inference demo code

### DIFF
--- a/docs/LLaVA_Video_1003.md
+++ b/docs/LLaVA_Video_1003.md
@@ -32,7 +32,7 @@ import warnings
 from decord import VideoReader, cpu
 import numpy as np
 warnings.filterwarnings("ignore")
-def load_video(self, video_path, max_frames_num,fps=1,force_sample=False):
+def load_video(video_path, max_frames_num,fps=1,force_sample=False):
     if max_frames_num == 0:
         return np.zeros((1, 336, 336, 3))
     vr = VideoReader(video_path, ctx=cpu(0),num_threads=1)
@@ -57,7 +57,7 @@ device_map = "auto"
 tokenizer, model, image_processor, max_length = load_pretrained_model(pretrained, None, model_name, torch_dtype="bfloat16", device_map=device_map)  # Add any other thing you want to pass in llava_model_args
 model.eval()
 video_path = "XXXX"
-max_frames_num = "64"
+max_frames_num = 64
 video,frame_time,video_time = load_video(video_path, max_frames_num, 1, force_sample=True)
 video = image_processor.preprocess(video, return_tensors="pt")["pixel_values"].cuda().bfloat16()
 video = [video]


### PR DESCRIPTION
Fix code in Inference demo: load_video method signature and parameter type

Problem: In the demo code for inference provided in the [document](https://github.com/LLaVA-VL/LLaVA-NeXT/blob/main/docs/LLaVA_Video_1003.md), the `load_video` function does not require a `self` parameter; the `max_frames_num` parameter should seemingly be of type `int`, but the `string` type defined here will result in an error.
<img width="1250" height="907" alt="docs_fix" src="https://github.com/user-attachments/assets/a3bb1394-4640-4513-9520-539f13f363bf" />

Fix:
- Corrected load_video method signature by removing incorrect 'self' parameter
- Fixed max_frames_num parameter type from string "64" to integer 64