### PR TITLE
Add missing math and sys imports in llava_trainer.py

### DIFF
--- a/llava/train/llava_trainer.py
+++ b/llava/train/llava_trainer.py
@@ -1,4 +1,6 @@
+import math
 import os
+import sys
 import torch
 import torch.nn as nn
 import datetime


### PR DESCRIPTION
## Summary
- Adds `import math` and `import sys` to `llava/train/llava_trainer.py`
- `_inner_training_loop` uses `math.ceil()` and `sys.maxsize` but neither module was imported
- Training crashes with `NameError: name 'math' is not defined`

## Related Issue
Fixes #504

## Test plan
- [ ] Run training command to verify no more NameError
- [ ] Verify training proceeds normally