### PR TITLE
Fix LoRA freeze logic: mm_tunable_parts incorrectly unfreezes LLM backbone

### DIFF
--- a/llava/train/train.py
+++ b/llava/train/train.py
@@ -1617,6 +1617,12 @@ def train(attn_implementation=None):
             model.config.tune_mm_vision_resampler = training_args.tune_mm_vision_resampler = model_args.tune_mm_vision_resampler
             if model_args.tune_mm_mlp_adapter or model_args.tune_mm_vision_resampler:
                 model.requires_grad_(False)
+                # Restore LoRA trainability after global freeze
+                if training_args.lora_enable:
+                    for name, param in model.named_parameters():
+                        if "lora_" in name:
+                            param.requires_grad_(True)
+                    rank0_print("Restored LoRA parameters to trainable after global freeze (legacy branch).")
             if model_args.tune_mm_mlp_adapter:
                 for p in model.get_model().mm_projector.parameters():
                     p.requires_grad = True
@@ -1661,14 +1667,54 @@ def train(attn_implementation=None):
                     if "vision_tower" in name:
                         param.requires_grad_(True)
             if "mm_language_model" in tunable_parts:
+                if training_args.lora_enable:
+                    # LoRA mode: only unfreeze LoRA parameters, keep LLM backbone frozen
+                    rank0_print("LoRA enabled: unfreezing only LoRA parameters for LLM.")
+                else:
+                    # Full finetune mode: unfreeze entire LLM backbone
+                    for name, param in model.named_parameters():
+                        if "vision_tower" not in name and "mm_projector" not in name and "vision_resampler" not in name:
+                            param.requires_grad_(True)
+
+            # Ensure LoRA parameters are always trainable when lora_enable is True,
+            # regardless of which mm_tunable_parts are specified.
+            # model.requires_grad_(False) above freezes everything including LoRA weights
+            # injected by PEFT, so we must explicitly restore them here.
+            if training_args.lora_enable:
+                lora_param_count = 0
                 for name, param in model.named_parameters():
-                    if "vision_tower" not in name and "mm_projector" not in name and "vision_resampler" not in name:
+                    if "lora_" in name:
                         param.requires_grad_(True)
+                        lora_param_count += 1
+                rank0_print(f"Restored {lora_param_count} LoRA parameter tensors to trainable.")
+                if "mm_language_model" not in tunable_parts:
+                    rank0_print(
+                        "WARNING: lora_enable is True but 'mm_language_model' is not in mm_tunable_parts. "
+                        "LoRA parameters will still be trained. If you do not intend to train the language "
+                        "model at all, consider setting --lora_enable False to avoid unnecessary overhead."
+                    )
 
         total_params = sum(p.ds_numel if hasattr(p, "ds_numel") else p.numel() for p in model.parameters())
         trainable_params = sum(p.ds_numel if hasattr(p, "ds_numel") else p.numel() for p in model.parameters() if p.requires_grad)
         rank0_print(f"Total parameters: ~{total_params/1e6:.2f} MB)")
         rank0_print(f"Trainable parameters: ~{trainable_params/1e6:.2f} MB)")
+        # Print per-group trainable parameter breakdown for verification
+        trainable_groups = {"lora": 0, "mm_projector": 0, "vision_resampler": 0, "vision_tower": 0, "llm_base": 0}
+        for name, p in model.named_parameters():
+            if not p.requires_grad:
+                continue
+            n = p.ds_numel if hasattr(p, "ds_numel") else p.numel()
+            if "lora_" in name:
+                trainable_groups["lora"] += n
+            elif "mm_projector" in name:
+                trainable_groups["mm_projector"] += n
+            elif "vision_resampler" in name:
+                trainable_groups["vision_resampler"] += n
+            elif "vision_tower" in name:
+                trainable_groups["vision_tower"] += n
+            else:
+                trainable_groups["llm_base"] += n
+        rank0_print("Trainable parameter groups: " + ", ".join(f"{k}={v:,}" for k, v in trainable_groups.items()))
         if training_args.bits in [4, 8]:
             model.get_model().mm_projector.to(dtype=compute_dtype, device=training_args.device)
 

--- a/llava/train/train_dpo.py
+++ b/llava/train/train_dpo.py
@@ -1636,6 +1636,12 @@ def train(attn_implementation=None):
             model.config.tune_mm_vision_resampler = training_args.tune_mm_vision_resampler = model_args.tune_mm_vision_resampler
             if model_args.tune_mm_mlp_adapter or model_args.tune_mm_vision_resampler:
                 model.requires_grad_(False)
+                # Restore LoRA trainability after global freeze
+                if training_args.lora_enable:
+                    for name, param in model.named_parameters():
+                        if "lora_" in name:
+                            param.requires_grad_(True)
+                    rank0_print("Restored LoRA parameters to trainable after global freeze (legacy branch).")
             if model_args.tune_mm_mlp_adapter:
                 for p in model.get_model().mm_projector.parameters():
                     p.requires_grad = True
@@ -1680,14 +1686,54 @@ def train(attn_implementation=None):
                     if "vision_tower" in name:
                         param.requires_grad_(True)
             if "mm_language_model" in tunable_parts:
+                if training_args.lora_enable:
+                    # LoRA mode: only unfreeze LoRA parameters, keep LLM backbone frozen
+                    rank0_print("LoRA enabled: unfreezing only LoRA parameters for LLM.")
+                else:
+                    # Full finetune mode: unfreeze entire LLM backbone
+                    for name, param in model.named_parameters():
+                        if "vision_tower" not in name and "mm_projector" not in name and "vision_resampler" not in name:
+                            param.requires_grad_(True)
+
+            # Ensure LoRA parameters are always trainable when lora_enable is True,
+            # regardless of which mm_tunable_parts are specified.
+            # model.requires_grad_(False) above freezes everything including LoRA weights
+            # injected by PEFT, so we must explicitly restore them here.
+            if training_args.lora_enable:
+                lora_param_count = 0
                 for name, param in model.named_parameters():
-                    if "vision_tower" not in name and "mm_projector" not in name and "vision_resampler" not in name:
+                    if "lora_" in name:
                         param.requires_grad_(True)
+                        lora_param_count += 1
+                rank0_print(f"Restored {lora_param_count} LoRA parameter tensors to trainable.")
+                if "mm_language_model" not in tunable_parts:
+                    rank0_print(
+                        "WARNING: lora_enable is True but 'mm_language_model' is not in mm_tunable_parts. "
+                        "LoRA parameters will still be trained. If you do not intend to train the language "
+                        "model at all, consider setting --lora_enable False to avoid unnecessary overhead."
+                    )
 
         total_params = sum(p.ds_numel if hasattr(p, "ds_numel") else p.numel() for p in model.parameters())
         trainable_params = sum(p.ds_numel if hasattr(p, "ds_numel") else p.numel() for p in model.parameters() if p.requires_grad)
         rank0_print(f"Total parameters: ~{total_params/1e6:.2f} MB)")
         rank0_print(f"Trainable parameters: ~{trainable_params/1e6:.2f} MB)")
+        # Print per-group trainable parameter breakdown for verification
+        trainable_groups = {"lora": 0, "mm_projector": 0, "vision_resampler": 0, "vision_tower": 0, "llm_base": 0}
+        for name, p in model.named_parameters():
+            if not p.requires_grad:
+                continue
+            n = p.ds_numel if hasattr(p, "ds_numel") else p.numel()
+            if "lora_" in name:
+                trainable_groups["lora"] += n
+            elif "mm_projector" in name:
+                trainable_groups["mm_projector"] += n
+            elif "vision_resampler" in name:
+                trainable_groups["vision_resampler"] += n
+            elif "vision_tower" in name:
+                trainable_groups["vision_tower"] += n
+            else:
+                trainable_groups["llm_base"] += n
+        rank0_print("Trainable parameter groups: " + ", ".join(f"{k}={v:,}" for k, v in trainable_groups.items()))
         if training_args.bits in [4, 8]:
             model.get_model().mm_projector.to(dtype=compute_dtype, device=training_args.device)
 


### PR DESCRIPTION
## Summary

This PR fixes the LoRA parameter freeze/unfreeze logic when used together with `mm_tunable_parts` in both `train.py` and `train_dpo.py`.

**Issue:**  
When `--lora_enable True` and `--mm_tunable_parts` includes `mm_language_model`, the code was unfreezing **all** LLM backbone parameters instead of just LoRA weights, effectively turning LoRA fine-tuning into full fine-tuning. On the other hand, if `mm_language_model` was not included, LoRA parameters ended up frozen by `model.requires_grad_(False)` and never restored.

**Impact:**  
Users who configured `--mm_tunable_parts="mm_mlp_adapter,mm_language_model" --lora_enable True`—a common setup—were unknowingly performing full fine-tuning, which increased VRAM usage by ~3x and removed the intended LoRA efficiency benefits.

## Changes

- **`mm_language_model` branch:** Correctly distinguish between LoRA mode (unfreeze only LoRA parameters) and full fine-tune mode (unfreeze the entire LLM backbone).  
- **LoRA parameter restoration:** After any global `model.requires_grad_(False)`, LoRA parameters (`lora_*`) are explicitly restored to trainable. This applies to both the `mm_tunable_parts` branch and the legacy `tune_mm_mlp_adapter` branch.  
- **Warnings:** Log a warning when `lora_enable=True` but `mm_language_model` is not in `mm_tunable_parts`.  
- **Trainable parameter summary:** Log per-group parameter counts (LoRA, `mm_projector`, `vision_resampler`, `vision_tower`, `llm_base`) at startup to make verification easier.  
- **Files updated:** The fix is applied consistently to both `train.py` (SFT) and `train_dpo.py` (DPO).

## Before vs After

| Configuration | Before (bug) | After (fixed) |
|---|---|---|
| `mm_tunable_parts="mm_mlp_adapter,mm_language_model"` + `lora_enable=True` | LoRA + MLP + **entire LLM backbone** | LoRA + MLP only |
| `mm_tunable_parts="mm_mlp_adapter"` + `lora_enable=True` | MLP only (LoRA frozen) | LoRA + MLP |
| `mm_tunable_parts=None` + `tune_mm_mlp_adapter=True` + `lora_enable=True` | MLP only (LoRA frozen) | LoRA + MLP |

## Test Plan

- Run with `--mm_tunable_parts="mm_mlp_adapter,mm_language_model" --lora_enable True` and confirm log shows `llm_base=0` and `lora>0`.  
- Run with `--mm_tunable_parts="mm_mlp_adapter,mm_language_model" --lora_enable False` and confirm `llm_base>0` (full fine-tune unchanged).  
- Run with `--mm_tunable_parts="mm_mlp_adapter" --lora_enable True` and confirm both `lora>0` and `mm_projector>0`.  
- Verify VRAM usage is significantly lower in LoRA mode compared to before.

Fixes #508  
Related: #253, #438