### PR TITLE
Fix/lora mm tunable parts freeze bug

### DIFF
--- a/llava/train/llava_trainer.py
+++ b/llava/train/llava_trainer.py
@@ -48,6 +48,22 @@ def get_mm_adapter_state_maybe_zero_3(named_params, keys_to_match):
     return to_return
 
 
+def should_only_save_mm_adapter(args) -> bool:
+    # LoRA runs need full PEFT checkpoint handling, even when adapters are also trainable.
+    if getattr(args, "lora_enable", False):
+        return False
+
+    if getattr(args, "tune_mm_mlp_adapter", False):
+        return True
+
+    mm_tunable_parts = getattr(args, "mm_tunable_parts", None)
+    if not mm_tunable_parts:
+        return False
+
+    tunable_parts = [part.strip() for part in mm_tunable_parts.split(",") if part.strip()]
+    return len(tunable_parts) == 1 and tunable_parts[0] in {"mm_mlp_adapter", "mm_vision_resampler"}
+
+
 def split_to_even_chunks(indices, lengths, num_chunks):
     """
     Split a list of indices into `chunks` chunks of roughly equal lengths.
@@ -646,9 +662,7 @@ class LLaVATrainer(Trainer):
         return self.optimizer
 
     def _save_checkpoint(self, model, trial, metrics=None):
-        if getattr(self.args, "tune_mm_mlp_adapter", False) or (
-            hasattr(self.args, "mm_tunable_parts") and (len(self.args.mm_tunable_parts.split(",")) == 1 and ("mm_mlp_adapter" in self.args.mm_tunable_parts or "mm_vision_resampler" in self.args.mm_tunable_parts))
-        ):
+        if should_only_save_mm_adapter(self.args):
             from transformers.trainer_utils import PREFIX_CHECKPOINT_DIR
 
             checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}"
@@ -670,7 +684,7 @@ class LLaVATrainer(Trainer):
             super(LLaVATrainer, self)._save_checkpoint(model, trial, metrics)
 
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
-        if getattr(self.args, "tune_mm_mlp_adapter", False):
+        if should_only_save_mm_adapter(self.args):
             pass
         else:
             super(LLaVATrainer, self)._save(output_dir, state_dict)
@@ -1247,9 +1261,7 @@ class LLaVADPOTrainer(DPOTrainer):
             return super()._get_train_sampler()
 
     def _save_checkpoint(self, model, trial, metrics=None):
-        if getattr(self.args, "tune_mm_mlp_adapter", False) or (
-            hasattr(self.args, "mm_tunable_parts") and (len(self.args.mm_tunable_parts.split(",")) == 1 and ("mm_mlp_adapter" in self.args.mm_tunable_parts or "mm_vision_resampler" in self.args.mm_tunable_parts))
-        ):
+        if should_only_save_mm_adapter(self.args):
             from transformers.trainer_utils import PREFIX_CHECKPOINT_DIR
 
             checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}"
@@ -1268,11 +1280,6 @@ class LLaVADPOTrainer(DPOTrainer):
                 self.model.config.save_pretrained(output_dir)
                 torch.save(weight_to_save, os.path.join(output_dir, f"mm_projector.bin"))
         else:
-            # super(LLaVADPOTrainer, self)._save_checkpoint(model, trial, metrics)
-            # print(type(model))
-            # from transformers.modeling_utils import unwrap_model
-            # print(type(unwrap_model(model)))
-            # print(unwrap_model(model).config)
             if self.args.lora_enable:
                 from transformers.trainer_utils import PREFIX_CHECKPOINT_DIR
 
@@ -1287,7 +1294,7 @@ class LLaVADPOTrainer(DPOTrainer):
                 super(LLaVADPOTrainer, self)._save_checkpoint(model, trial, metrics)
 
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
-        if getattr(self.args, "tune_mm_mlp_adapter", False):
+        if should_only_save_mm_adapter(self.args):
             pass
         else:
             super(LLaVADPOTrainer, self)._save(output_dir, state_dict)

--- a/llava/train/train.py
+++ b/llava/train/train.py
@@ -1617,6 +1617,12 @@ def train(attn_implementation=None):
             model.config.tune_mm_vision_resampler = training_args.tune_mm_vision_resampler = model_args.tune_mm_vision_resampler
             if model_args.tune_mm_mlp_adapter or model_args.tune_mm_vision_resampler:
                 model.requires_grad_(False)
+                # Restore LoRA trainability after global freeze
+                if training_args.lora_enable:
+                    for name, param in model.named_parameters():
+                        if "lora_" in name:
+                            param.requires_grad_(True)
+                    rank0_print("Restored LoRA parameters to trainable after global freeze (legacy branch).")
             if model_args.tune_mm_mlp_adapter:
                 for p in model.get_model().mm_projector.parameters():
                     p.requires_grad = True
@@ -1661,14 +1667,54 @@ def train(attn_implementation=None):
                     if "vision_tower" in name:
                         param.requires_grad_(True)
             if "mm_language_model" in tunable_parts:
+                if training_args.lora_enable:
+                    # LoRA mode: only unfreeze LoRA parameters, keep LLM backbone frozen
+                    rank0_print("LoRA enabled: unfreezing only LoRA parameters for LLM.")
+                else:
+                    # Full finetune mode: unfreeze entire LLM backbone
+                    for name, param in model.named_parameters():
+                        if "vision_tower" not in name and "mm_projector" not in name and "vision_resampler" not in name:
+                            param.requires_grad_(True)
+
+            # Ensure LoRA parameters are always trainable when lora_enable is True,
+            # regardless of which mm_tunable_parts are specified.
+            # model.requires_grad_(False) above freezes everything including LoRA weights
+            # injected by PEFT, so we must explicitly restore them here.
+            if training_args.lora_enable:
+                lora_param_count = 0
                 for name, param in model.named_parameters():
-                    if "vision_tower" not in name and "mm_projector" not in name and "vision_resampler" not in name:
+                    if "lora_" in name:
                         param.requires_grad_(True)
+                        lora_param_count += 1
+                rank0_print(f"Restored {lora_param_count} LoRA parameter tensors to trainable.")
+                if "mm_language_model" not in tunable_parts:
+                    rank0_print(
+                        "WARNING: lora_enable is True but 'mm_language_model' is not in mm_tunable_parts. "
+                        "LoRA parameters will still be trained. If you do not intend to train the language "
+                        "model at all, consider setting --lora_enable False to avoid unnecessary overhead."
+                    )
 
         total_params = sum(p.ds_numel if hasattr(p, "ds_numel") else p.numel() for p in model.parameters())
         trainable_params = sum(p.ds_numel if hasattr(p, "ds_numel") else p.numel() for p in model.parameters() if p.requires_grad)
         rank0_print(f"Total parameters: ~{total_params/1e6:.2f} MB)")
         rank0_print(f"Trainable parameters: ~{trainable_params/1e6:.2f} MB)")
+        # Print per-group trainable parameter breakdown for verification
+        trainable_groups = {"lora": 0, "mm_projector": 0, "vision_resampler": 0, "vision_tower": 0, "llm_base": 0}
+        for name, p in model.named_parameters():
+            if not p.requires_grad:
+                continue
+            n = p.ds_numel if hasattr(p, "ds_numel") else p.numel()
+            if "lora_" in name:
+                trainable_groups["lora"] += n
+            elif "mm_projector" in name:
+                trainable_groups["mm_projector"] += n
+            elif "vision_resampler" in name:
+                trainable_groups["vision_resampler"] += n
+            elif "vision_tower" in name:
+                trainable_groups["vision_tower"] += n
+            else:
+                trainable_groups["llm_base"] += n
+        rank0_print("Trainable parameter groups: " + ", ".join(f"{k}={v:,}" for k, v in trainable_groups.items()))
         if training_args.bits in [4, 8]:
             model.get_model().mm_projector.to(dtype=compute_dtype, device=training_args.device)
 

--- a/llava/train/train_dpo.py
+++ b/llava/train/train_dpo.py
@@ -1636,6 +1636,12 @@ def train(attn_implementation=None):
             model.config.tune_mm_vision_resampler = training_args.tune_mm_vision_resampler = model_args.tune_mm_vision_resampler
             if model_args.tune_mm_mlp_adapter or model_args.tune_mm_vision_resampler:
                 model.requires_grad_(False)
+                # Restore LoRA trainability after global freeze
+                if training_args.lora_enable:
+                    for name, param in model.named_parameters():
+                        if "lora_" in name:
+                            param.requires_grad_(True)
+                    rank0_print("Restored LoRA parameters to trainable after global freeze (legacy branch).")
             if model_args.tune_mm_mlp_adapter:
                 for p in model.get_model().mm_projector.parameters():
                     p.requires_grad = True
@@ -1680,14 +1686,54 @@ def train(attn_implementation=None):
                     if "vision_tower" in name:
                         param.requires_grad_(True)
             if "mm_language_model" in tunable_parts:
+                if training_args.lora_enable:
+                    # LoRA mode: only unfreeze LoRA parameters, keep LLM backbone frozen
+                    rank0_print("LoRA enabled: unfreezing only LoRA parameters for LLM.")
+                else:
+                    # Full finetune mode: unfreeze entire LLM backbone
+                    for name, param in model.named_parameters():
+                        if "vision_tower" not in name and "mm_projector" not in name and "vision_resampler" not in name:
+                            param.requires_grad_(True)
+
+            # Ensure LoRA parameters are always trainable when lora_enable is True,
+            # regardless of which mm_tunable_parts are specified.
+            # model.requires_grad_(False) above freezes everything including LoRA weights
+            # injected by PEFT, so we must explicitly restore them here.
+            if training_args.lora_enable:
+                lora_param_count = 0
                 for name, param in model.named_parameters():
-                    if "vision_tower" not in name and "mm_projector" not in name and "vision_resampler" not in name:
+                    if "lora_" in name:
                         param.requires_grad_(True)
+                        lora_param_count += 1
+                rank0_print(f"Restored {lora_param_count} LoRA parameter tensors to trainable.")
+                if "mm_language_model" not in tunable_parts:
+                    rank0_print(
+                        "WARNING: lora_enable is True but 'mm_language_model' is not in mm_tunable_parts. "
+                        "LoRA parameters will still be trained. If you do not intend to train the language "
+                        "model at all, consider setting --lora_enable False to avoid unnecessary overhead."
+                    )
 
         total_params = sum(p.ds_numel if hasattr(p, "ds_numel") else p.numel() for p in model.parameters())
         trainable_params = sum(p.ds_numel if hasattr(p, "ds_numel") else p.numel() for p in model.parameters() if p.requires_grad)
         rank0_print(f"Total parameters: ~{total_params/1e6:.2f} MB)")
         rank0_print(f"Trainable parameters: ~{trainable_params/1e6:.2f} MB)")
+        # Print per-group trainable parameter breakdown for verification
+        trainable_groups = {"lora": 0, "mm_projector": 0, "vision_resampler": 0, "vision_tower": 0, "llm_base": 0}
+        for name, p in model.named_parameters():
+            if not p.requires_grad:
+                continue
+            n = p.ds_numel if hasattr(p, "ds_numel") else p.numel()
+            if "lora_" in name:
+                trainable_groups["lora"] += n
+            elif "mm_projector" in name:
+                trainable_groups["mm_projector"] += n
+            elif "vision_resampler" in name:
+                trainable_groups["vision_resampler"] += n
+            elif "vision_tower" in name:
+                trainable_groups["vision_tower"] += n
+            else:
+                trainable_groups["llm_base"] += n
+        rank0_print("Trainable parameter groups: " + ", ".join(f"{k}={v:,}" for k, v in trainable_groups.items()))
         if training_args.bits in [4, 8]:
             model.get_model().mm_projector.to(dtype=compute_dtype, device=training_args.device)
 


### PR DESCRIPTION
  Title:
  Fix LoRA freeze logic and checkpoint saving with mm_tunable_parts (updated #510 + #511)

  Body:

  ## Background

  This PR is an updated re-submission of the previously closed #510, now incorporating the checkpoint saving fix identified by @Luodian in #511. The original #510 was accidentally closed due to a branch issue,
  and this version combines both fixes into a single PR.

  ## Summary

  This PR fixes two related bugs when combining LoRA training with `mm_tunable_parts` configuration:

  ### Bug 1: Parameter freeze logic — from #510 (train.py, train_dpo.py)

  - When `lora_enable=True` and `mm_tunable_parts` includes `mm_language_model`, the original code unfreezes the **entire** LLM backbone instead of only LoRA weights, effectively converting LoRA fine-tuning
  into full fine-tuning (~3x VRAM increase).
  - When `mm_language_model` is **not** in `mm_tunable_parts`, LoRA parameters are frozen by `model.requires_grad_(False)` and never restored.

  **Fix:** Distinguish LoRA mode vs full-finetune mode in the `mm_language_model` branch; explicitly restore LoRA parameter trainability after global freeze; apply the same fix to the legacy
  `tune_mm_mlp_adapter` codepath.

  ### Bug 2: Checkpoint saving omits LoRA weights — from #511 (llava_trainer.py)

  - With configs like `--mm_tunable_parts="mm_mlp_adapter" --lora_enable True`, training works correctly (after Bug 1 fix), but the checkpoint saving logic enters the adapter-only branch, saving only
  `mm_projector.bin` and **omitting LoRA weights entirely**. This prevents proper checkpoint resumption.
  - Credit to @Luodian for identifying this issue.

  **Fix:** Add `should_only_save_mm_adapter()` helper that returns `False` when `lora_enable=True`, ensuring checkpoints go through the full PEFT saving path. Replaces duplicated inline conditions in both
  `LLaVATrainer` and `LLaVADPOTrainer`.

  ## Before/After behavior

  | Configuration | Before | After |
  |---|---|---|
  | `mm_tunable_parts="mm_mlp_adapter,mm_language_model"` + LoRA | LoRA + MLP + **entire LLM** (wrong) | LoRA + MLP only |
  | `mm_tunable_parts="mm_mlp_adapter"` + LoRA | MLP only, LoRA frozen (wrong) | LoRA + MLP |
  | `mm_tunable_parts="mm_mlp_adapter"` + LoRA checkpoint | Saves only `mm_projector.bin`, **LoRA weights lost** (wrong) | Full PEFT checkpoint including LoRA |

  ## Changed files

  - `llava/train/train.py` — freeze logic fix (from #510)
  - `llava/train/train_dpo.py` — freeze logic fix (from #510)
  - `llava/train/llava_trainer.py` — checkpoint saving fix (from #511)

  Fixes #508
  Related: #253, #438
